### PR TITLE
Added malibu home page; added Inventory models to admin page

### DIFF
--- a/malibu/inventory/admin.py
+++ b/malibu/inventory/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
+from .models import Product, Lot
 
-# Register your models here.
+
+admin.site.register(Product)
+admin.site.register(Lot)

--- a/malibu/inventory/views.py
+++ b/malibu/inventory/views.py
@@ -9,11 +9,7 @@ def index(request):
     context = {'products': products}
     return render(request, 'inventory/index.html', context)
 
+
 def detail(request, sku_number):
     item = get_object_or_404(Product, pk=sku_number)
     return render(request, 'inventory/detail.html', {'item': item})
-
-
-
-
-# details view page (click the line item link to see more details on the item)

--- a/malibu/malibu/settings.py
+++ b/malibu/malibu/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'inventory.apps.InventoryConfig',
+    'listings.apps.ListingsConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -55,7 +56,7 @@ ROOT_URLCONF = 'malibu.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ['templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/malibu/malibu/urls.py
+++ b/malibu/malibu/urls.py
@@ -15,9 +15,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from . import views
 
 urlpatterns = [
-    path('listings/', include('listings.urls')),
+    path('', views.home, name='home'),
     path('admin/', admin.site.urls),
     path('inventory/', include('inventory.urls')),
+    path('listings/', include('listings.urls')),
 ]

--- a/malibu/malibu/views.py
+++ b/malibu/malibu/views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def home(request):
+    return render(request, 'index.html')

--- a/malibu/templates/index.html
+++ b/malibu/templates/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Home page</title>
+</head>
+<body>
+    <h1>Malibu</h1>
+    <ul>
+        <li><a href="/admin">Admin</a></li>
+        <li><a href="/inventory">Inventory</a></li>
+        <li><a href="/listings">Listings</a></li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
Hi Robby - Here are some small changes I made. Please look them over and merge this PR if you like them. Here's what I did.

1. I added master home page under a new templates directory next to the malibu project directory - in the same directory as db.sqlite and manage.py. This directory will hold templates for the home page. Templates specific to apps like Inventory and Listings will be in their own template directories under those app directories. This is a simple home page that we can flesh out later with lots of good html/css/javascript if we want.

2. I registered the Product and Lot models with the admin page so we can create lots and products there. This is only temporary until we figure out how we want to manage inventory within the inventory app. For now, you can log into the admin and see new Product and Lot entries in the database models. If you click on one, you can add a new Lot or Product. Then the products you add will show up on the inventory page. (Remember, we added a template to display existing Product database entries, but we didn't have any so we couldn't see any - well, now we can.)

3. Minor clean up in unrelated files - spaces, blank lines, etc.